### PR TITLE
docs: add overview and mode card

### DIFF
--- a/MODE_CARD.md
+++ b/MODE_CARD.md
@@ -1,0 +1,15 @@
+# Adaptive Golden Field — Mode Card
+
+Reference sheet summarizing available simulation modes and their scripts.
+
+| Mode | Script | Description |
+|------|--------|-------------|
+| Inspiral | `inspiral_gwstyle_phi_a.py` | GW-style inspiral of rays over an adaptive field |
+| Precessing Inspiral | `inspiral_precessing_phi_a.py` | Kerr-like periapsis precession |
+| Multi-mode Ringdown | `ringdown_multimode.py` | Superposed damped oscillatory modes with focus correlation |
+| Ringdown Lensing | `ringdown_lensing.py` | Single-mode lensing plus φ_a vs focus correlation |
+| Stochastic Hybrid | `stochastic_hybrid_phi_a.py` | OU-noise-driven hybrid trajectory |
+| Cinematic Cycle | `cinematic_adaptive_golden.py` | End-to-end animation from inspiral to ringdown |
+| Spin Comparison | `spin_comparison_panel.py` | Static field vs spin-enhanced comparison panel |
+
+**License**: MIT

--- a/README.md
+++ b/README.md
@@ -1,99 +1,29 @@
-# φ_a Visualization Scripts
+# Adaptive Golden Field (ϕ_a) — Lensing, Inspiral, Ringdown
 
-Two small, dependency-light scripts to generate visual artifacts for adaptive field / inspiral style demonstrations. Designed to run locally without any external downloads beyond PyPI basics.
+**What:** Field-aware Fibonacci where the golden ratio becomes a dynamic field ϕ_a(x,t),
+coupled to gravity-like potentials to generate adaptive spirals, caustics, and CAD-ready geometry.
 
-## Quick Install
+**Highlights**
+- Inspiral → precession → multi-mode ringdown (cinematic clip)
+- Optical geodesics over ϕ_a; focus metric (1/std of ray crossings)
+- Stochastic “protein–GW” hybrid (OU noise) + correlation tests
+- Plain-text equations for X + equation-card PNGs
 
+**Quickstart**
 ```bash
-python -m venv .venv
-source .venv/bin/activate  # macOS/Linux
-pip install --upgrade pip
-pip install numpy matplotlib imageio pillow imageio-ffmpeg
+python -m venv .venv && source .venv/bin/activate  # Windows: .venv\Scripts\activate
+pip install numpy matplotlib imageio pillow
+python cinematic_adaptive_golden.py
 ```
 
-(If you do not need MP4 output you can omit `imageio-ffmpeg`.)
+**Scripts**
 
-## Scripts
+* `inspiral_gwstyle_phi_a.py` — GW-like inspiral
+* `inspiral_precessing_phi_a.py` — periapsis precession (Kerr-like)
+* `ringdown_multimode.py` — multi-mode beats + correlation
+* `ringdown_lensing.py` — single-mode lensing + focus correlation
+* `stochastic_hybrid_phi_a.py` — noisy hybrid (protein–GW analog)
+* `cinematic_adaptive_golden.py` — full life-cycle animation
+* `spin_comparison_panel.py` — base vs spin-augmented field comparison
 
-### 1. `inspiral_gwstyle_phi_a.py`
-Generates an inspiral animation of ray trajectories over an adaptive `phi_a` scalar field derived from a softened binary potential and curvature-like invariants.
-
-Outputs (by default):
-- `inspiral_gwstyle_phi_a.gif`
-- `inspiral_gwstyle_phi_a.mp4` (if the ffmpeg backend is available)
-
-Run with defaults:
-```bash
-python inspiral_gwstyle_phi_a.py
-```
-
-Progress logging & only GIF:
-```bash
-python inspiral_gwstyle_phi_a.py --progress --gif --no-mp4
-```
-
-Only MP4 with custom fps & frames:
-```bash
-python inspiral_gwstyle_phi_a.py --no-gif --mp4 --fps 10 --frames 40
-```
-
-Change output stem:
-```bash
-python inspiral_gwstyle_phi_a.py -o my_inspiral
-```
-
-Environment variable alternative for frame count:
-```bash
-FRAMES=30 python inspiral_gwstyle_phi_a.py
-```
-
-Key adjustable parameters (CLI flags):
-- `--fps` Frame rate.
-- `--frames` Number of frames (or use `FRAMES` env var).
-- `--width / --height` Figure size in inches.
-- `--gif / --no-gif`, `--mp4 / --no-mp4` format toggles.
-- `-o / --output-stem` Base name for files.
-- `--progress` Per-frame logging.
-
-### 2. `spin_comparison_panel.py`
-Creates a side-by-side PNG showing base `sigma` field (no spin) vs a spin-augmented field using a simple additive pseudo-spin term ~ J/r^3.
-
-Run:
-```bash
-python spin_comparison_panel.py
-```
-
-Custom spins / output file:
-```bash
-python spin_comparison_panel.py --j1 0.4 --j2 -0.25 --outfile panel.png
-```
-
-Adjust grid size & extent:
-```bash
-python spin_comparison_panel.py --n 300 --ext 8.0
-```
-
-Colormap & DPI:
-```bash
-python spin_comparison_panel.py --cmap plasma --dpi 300
-```
-
-### Notes on the Physics Simplifications
-- Potentials are Newtonian-softened; no GR solver invoked.
-- `phi_a` heuristic depends on Laplacian & Hessian norm (trace / invariants) normalized to [0,1].
-- Ray integration uses a custom geodesic-like update with gradients of an optical conformal factor derived from the potential.
-- Spin field is a toy model (dipole-like falloff) added linearly in log-conformal factor space for visual differentiation.
-
-### Troubleshooting
-- If MP4 writing fails: ensure `ffmpeg` is on PATH or install `imageio-ffmpeg` (`pip install imageio-ffmpeg`).
-- If you see Import errors in an IDE: verify the virtual environment is active.
-- Large grids or many frames can increase memory usage; reduce `--frames` or grid size (`N` constant in script) if needed.
-
-### Possible Extensions
-- Add color mapping to ray curvature or affine parameter.
-- Adaptive step size integration for rays.
-- More realistic inspiral dynamics (e.g., PN evolution of separation & spins).
-- Export frame set to a numbered directory for further post-processing.
-
----
-Enjoy exploring the fields! Feel free to adapt / extend.
+**License**: MIT


### PR DESCRIPTION
## Summary
- rewrite README with quickstart and script overview
- add MODE_CARD table listing simulation modes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e72447468832fae5d5d116031f72c